### PR TITLE
Add GCP ingestion pipeline scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,18 @@ python -m sports.run live --symbol 'Home vs Away (Match Odds)' --side back --odd
 - `sports/llm.py`, `sports/news.py` – news fetch + LLM summaries
 - `sports/webapp.py` – Flask dashboard
 - `sports/run.py` – CLI entrypoint
+
+## GCP ingestion pipeline
+
+A basic pipeline using Google Cloud native services is included. Deploy
+`sports/gcp_ingest_service.py` to Cloud Run and create a Pub/Sub topic with a
+push subscription pointing at the service. Jobs can then be published with
+`scripts/publish_ingest_job.py`:
+
+```bash
+python scripts/publish_ingest_job.py --project <PROJECT> --topic <TOPIC> \
+    --url https://example.com/file.csv --bucket my-bucket --name raw/file.csv
+```
+
+The Cloud Run service downloads the referenced URL and stores the contents in
+the specified Cloud Storage bucket for downstream processing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ openai>=1.40
 python-telegram-bot
 python-dotenv>=1.0
 google-cloud-bigquery>=3.20
+google-cloud-pubsub>=2.20
+google-cloud-storage>=2.14
 scikit-learn>=1.3
 requests>=2.31
 websockets==12.0

--- a/scripts/publish_ingest_job.py
+++ b/scripts/publish_ingest_job.py
@@ -1,0 +1,24 @@
+"""CLI helper to publish ingestion jobs to a Pub/Sub topic."""
+from __future__ import annotations
+
+import argparse
+
+from sports.gcp import publish_pubsub_message
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Publish an ingestion job to Pub/Sub")
+    p.add_argument("--project", required=True, help="GCP project ID")
+    p.add_argument("--topic", required=True, help="Pub/Sub topic ID")
+    p.add_argument("--url", required=True, help="Source URL to download")
+    p.add_argument("--bucket", required=True, help="Cloud Storage bucket to write to")
+    p.add_argument("--name", required=True, help="Destination object name")
+    args = p.parse_args()
+
+    payload = {"url": args.url, "bucket": args.bucket, "name": args.name}
+    msg_id = publish_pubsub_message(args.project, args.topic, payload)
+    print("Published message", msg_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/sports/gcp.py
+++ b/sports/gcp.py
@@ -1,0 +1,41 @@
+"""Utilities for interacting with Google Cloud services.
+
+This module provides thin wrappers around Pub/Sub and Cloud Storage so the
+application can start to adopt Google Cloud's native data ingestion tools.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from typing import Dict, Any
+
+from google.cloud import pubsub_v1, storage
+
+
+def publish_pubsub_message(project_id: str, topic_id: str, payload: Dict[str, Any]) -> str:
+    """Publish a JSON payload to a Pub/Sub topic and return the message ID."""
+    publisher = pubsub_v1.PublisherClient()
+    topic_path = publisher.topic_path(project_id, topic_id)
+    data = json.dumps(payload).encode("utf-8")
+    future = publisher.publish(topic_path, data)
+    return future.result()
+
+
+def parse_pubsub_envelope(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    """Decode a Pub/Sub push request envelope into a Python dictionary."""
+    if not envelope or "message" not in envelope:
+        raise ValueError("Invalid Pub/Sub message format")
+    message = envelope["message"]
+    data = message.get("data", "")
+    if data:
+        decoded = base64.b64decode(data).decode("utf-8")
+        return json.loads(decoded)
+    return {}
+
+
+def upload_text_to_bucket(bucket_name: str, destination_blob: str, text: str) -> None:
+    """Upload arbitrary text content to a Cloud Storage bucket."""
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob)
+    blob.upload_from_string(text)

--- a/sports/gcp_ingest_service.py
+++ b/sports/gcp_ingest_service.py
@@ -1,0 +1,43 @@
+"""Cloud Run entrypoint to handle ingestion jobs from Pub/Sub.
+
+The service expects Pub/Sub push messages containing JSON with the keys
+``url`` (HTTP resource to fetch), ``bucket`` (Cloud Storage bucket), and
+``name`` (destination object name). The referenced resource is downloaded
+and stored in the given bucket.
+"""
+from __future__ import annotations
+
+import os
+import requests
+from flask import Flask, request
+
+from sports.gcp import parse_pubsub_envelope, upload_text_to_bucket
+
+app = Flask(__name__)
+
+
+@app.post("/")
+def handle_pubsub() -> tuple[str, int]:
+    """Endpoint for Pub/Sub push subscriptions."""
+    try:
+        payload = parse_pubsub_envelope(request.get_json())
+    except ValueError:
+        return ("Bad Request", 400)
+
+    url = payload.get("url")
+    bucket = payload.get("bucket")
+    name = payload.get("name")
+
+    if url and bucket and name:
+        resp = requests.get(url)
+        resp.raise_for_status()
+        upload_text_to_bucket(bucket, name, resp.text)
+    else:
+        # If required fields are missing we still return 204 so Pub/Sub doesn't retry indefinitely.
+        return ("Missing fields", 204)
+
+    return ("", 204)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "8080")))


### PR DESCRIPTION
## Summary
- Introduce `sports/gcp.py` with helpers for Pub/Sub and Cloud Storage
- Add Cloud Run ingestion service consuming Pub/Sub jobs and uploading to GCS
- Provide CLI to publish ingestion jobs and document usage

## Testing
- `pip install -r requirements.txt`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b9eff5c50c83219e077a089d348e73